### PR TITLE
Fixing Leaflet map

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    crossOrigin: 'anonymous'
+}

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "react": "16.13.1",
     "react-dom": "16.13.1",
     "react-icons": "^3.11.0",
-    "react-leaflet": "^2.7.0"
+    "react-leaflet": "^2.7.0",
+    "react-leaflet-universal": "^2.2.1"
   },
   "devDependencies": {
     "@types/node": "^14.11.8",

--- a/src/components/LeafletMap.tsx
+++ b/src/components/LeafletMap.tsx
@@ -1,4 +1,4 @@
-import { Map, TileLayer } from 'react-leaflet'
+import { Map, TileLayer } from 'react-leaflet-universal'
 import 'leaflet/dist/leaflet.css'
 
 const LeafletMap = () => (

--- a/src/components/LeafletMapDynamic.tsx
+++ b/src/components/LeafletMapDynamic.tsx
@@ -1,7 +1,0 @@
-import dynamic from 'next/dynamic'
-
-const LeafletMapDynamic = dynamic(() => import('./LeafletMap'), {
-    ssr: false
-})
-
-export default LeafletMapDynamic

--- a/src/pages/map.tsx
+++ b/src/pages/map.tsx
@@ -2,7 +2,7 @@ import styles from '../../styles/Map.module.css'
 import Link from 'next/link'
 import { FiPlus } from 'react-icons/fi'
 
-import LeafletMapDynamic from '../components/LeafletMapDynamic'
+import LeafletMap from '../components/LeafletMap'
 
 export default function Map() {
     return (
@@ -23,7 +23,8 @@ export default function Map() {
                 </footer>
             </aside>
 
-            <LeafletMapDynamic />
+            {/* <LeafletMapDynamic /> */}
+            <LeafletMap />
 
             <Link href="">
                 <a className={styles.btnCreateOrphanage}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4031,6 +4031,11 @@ react-is@16.13.1, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-leaflet-universal@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/react-leaflet-universal/-/react-leaflet-universal-2.2.1.tgz#4458cb9be578ba41658d3fcca3bcc0b674630c32"
+  integrity sha512-5eXeAylLcHQSjD06DV6Po98NntShXVI47Kj+uZQSG0byfJDbbFOHFPCLcVZa7kY/TAqXuQq8BK4RyV7kPhf70A==
+
 react-leaflet@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-2.7.0.tgz#0e0e452a4903029f0bb564771eab8cf9db8e4517"


### PR DESCRIPTION
In #2, Leaflet map was not loading it completely. To solve it, i used `react-leaflet-universal` instead of `react-leaflet` package, because `react-leaflet-universal` doesn't need use dynamic component - it load both side (client/server)

On "Preload CSS Crossorigin Warning", like [Next.js blog](https://nextjs.org/blog/next-8#new-crossorigin-config-option), i set `next.config.js` like:

```js
module.exports = {
  crossOrigin: 'anonymous'
}
```